### PR TITLE
v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.0.6
+
+- `PCanvas`:
+  - Constructor: added parameter `initialPixels`. 
+  - Added method `setPixels`.
+  - Added support for `clip` and `subClip`.
+  - Added `transform`: new `PcanvasTransform` class.
+  - Added `saveState`, `restoreState` and `callWithGuardedState`.
+  - `elements` now is unmmodifiable.
+- `PCanvasPixels`:
+  - Added `setPixel`, `setPixelFrom`, `setPixelsLineFrom`, `setPixelsColumnFrom` and `setPixelsRectFrom`.
+  - Added `putPixels`, `copyRectangle` and `copyRect`.
+  - Added `toPCanvas`, `toPNG` and `toDataUrl`.
+- New `PCanvasElementContainer`:
+  - New `PCanvasPanel2D` and `PRectangleElement`.
+- `PRectangle`:
+  - Added `intersectsRectangle`, `intersects` and `intersection`.
+  - Added `containsRectangle`, `contains`, `containsPoint` and `containsXY`.
+  - Added `transform`.
+- image: ^4.0.7
+- test: ^1.22.1
+- collection: ^1.16.0
+
 ## 1.0.5
 
 - Add support to stroke/fill circles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Added `saveState`, `restoreState` and `callWithGuardedState`.
   - `elements` now is unmmodifiable.
 - `PCanvasPixels`:
+  - New constructor `PCanvasPixels.fromBytes`.
   - Added `setPixel`, `setPixelFrom`, `setPixelsLineFrom`, `setPixelsColumnFrom` and `setPixelsRectFrom`.
   - Added `putPixels`, `copyRectangle` and `copyRect`.
   - Added `toPCanvas`, `toPNG` and `toDataUrl`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/pcanvas.svg?logo=dart&logoColor=00b9fc)](https://pub.dev/packages/pcanvas)
 [![Null Safety](https://img.shields.io/badge/null-safety-brightgreen)](https://dart.dev/null-safety)
-[![CI](https://img.shields.io/github/workflow/status/gmpassos/pcanvas/Dart%20CI/master?logo=github-actions&logoColor=white)](https://github.com/gmpassos/pcanvas/actions)
+[![Dart CI](https://github.com/gmpassos/pcanvas/actions/workflows/dart.yml/badge.svg?branch=master)](https://github.com/gmpassos/pcanvas/actions/workflows/dart.yml)
 [![GitHub Tag](https://img.shields.io/github/v/tag/gmpassos/pcanvas?logo=git&logoColor=white)](https://github.com/gmpassos/pcanvas/releases)
 [![New Commits](https://img.shields.io/github/commits-since/gmpassos/pcanvas/latest?logo=git&logoColor=white)](https://github.com/gmpassos/pcanvas/network)
 [![Last Commits](https://img.shields.io/github/last-commit/gmpassos/pcanvas?logo=git&logoColor=white)](https://github.com/gmpassos/pcanvas/commits/master)

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,7 @@
+
+tags:
+  # Slow tests.
+  slow:
+    timeout: 180s
+
+platforms: [vm, chrome]

--- a/lib/src/pcanvas_base.dart
+++ b/lib/src/pcanvas_base.dart
@@ -886,6 +886,28 @@ abstract class PCanvasPixels {
   PCanvasPixels.blank(this.width, this.height)
       : pixels = Uint32List(width * height);
 
+  /// Construct a [PCanvasPixels] from [bytes].
+  /// - If [bytes] is a [TypedData] it will be converted to an [Uint32List]
+  ///   through its internal [ByteBuffer].
+  /// - If [bytes] is not a [TypedData] it will be converted to a [Uint8ClampedList.fromList]
+  ///   and after that to an [Uint32List].
+  /// - Note that in most systems the [Endian.host] is 'little-endian'.
+  /// - Modern CPU architectures are `little-endian`, like `x86` and `ARMv8`.
+  PCanvasPixels.fromBytes(int width, int height, List<int> bytes)
+      : this.fromPixels(width, height, _bytesToUint32List(bytes));
+
+  static Uint32List _bytesToUint32List(List<int> bytes) {
+    if (bytes is TypedData) {
+      var td = bytes as TypedData;
+      return td.buffer.asUint32List(td.offsetInBytes, td.lengthInBytes ~/ 4);
+    } else {
+      var bs = Uint8ClampedList.fromList(bytes);
+      return bs.buffer.asUint32List(bs.offsetInBytes, bs.lengthInBytes ~/ 4);
+    }
+  }
+
+  /// Construct a [PCanvasPixels] from [pixels].
+  /// - [pixels] is expected to be an [Uint32List] in the same [format] of this class implementation.
   PCanvasPixels.fromPixels(this.width, this.height, this.pixels);
 
   /// Creates a blank [PCanvasPixels] instance with the same [format] of this one.
@@ -1031,6 +1053,9 @@ abstract class PCanvasPixels {
 class PCanvasPixelsARGB extends PCanvasPixels {
   PCanvasPixelsARGB.blank(super.width, super.height) : super.blank();
 
+  PCanvasPixelsARGB.fromBytes(super.width, super.height, super.bytes)
+      : super.fromBytes();
+
   PCanvasPixelsARGB.fromPixels(super.width, super.height, super.pixels)
       : super.fromPixels();
 
@@ -1100,6 +1125,9 @@ class PCanvasPixelsARGB extends PCanvasPixels {
 class PCanvasPixelsABGR extends PCanvasPixels {
   PCanvasPixelsABGR.blank(super.width, super.height) : super.blank();
 
+  PCanvasPixelsABGR.fromBytes(super.width, super.height, super.bytes)
+      : super.fromBytes();
+
   PCanvasPixelsABGR.fromPixels(super.width, super.height, super.pixels)
       : super.fromPixels();
 
@@ -1168,6 +1196,9 @@ class PCanvasPixelsABGR extends PCanvasPixels {
 /// [PCanvasPixels] in `RGBA` format.
 class PCanvasPixelsRGBA extends PCanvasPixels {
   PCanvasPixelsRGBA.blank(super.width, super.height) : super.blank();
+
+  PCanvasPixelsRGBA.fromBytes(super.width, super.height, super.bytes)
+      : super.fromBytes();
 
   PCanvasPixelsRGBA.fromPixels(super.width, super.height, super.pixels)
       : super.fromPixels();

--- a/lib/src/pcanvas_bitmap.dart
+++ b/lib/src/pcanvas_bitmap.dart
@@ -48,8 +48,6 @@ class PCanvasBitmap extends PCanvas {
 
     if (w <= 0 || h <= 0) return;
 
-    pixels = pixels.toPCanvasPixelsABGR();
-
     for (var y1 = 0; y1 < h; ++y1) {
       for (var x1 = 0; x1 < w; ++x1) {
         var p = pixels.getImageColor(x, y);
@@ -707,7 +705,7 @@ class PCanvasBitmap extends PCanvas {
     if (paintRectClipped.isZeroDimension) return null;
 
     var pixels =
-        PCanvasPixelsABGR.fromPixels(width, height, _bitmap.dataAsUint32List);
+        PCanvasPixelsRGBA.fromBytes(width, height, _bitmap.dataAsUint8List);
 
     var cp1 = pixels.copyRectangle(paintRect)!;
 
@@ -753,7 +751,7 @@ class PCanvasBitmap extends PCanvas {
 
   @override
   PCanvasPixels get pixels =>
-      PCanvasPixelsABGR.fromPixels(width, height, _bitmap.dataAsUint32List);
+      PCanvasPixelsABGR.fromBytes(width, height, _bitmap.dataAsUint8List);
 
   @override
   FutureOr<Uint8List> toPNG() => img.encodePng(_bitmap);
@@ -958,11 +956,10 @@ extension _PCanvasPixelsExtension on PCanvasPixels {
 }
 
 extension _ImageExtension on img.Image {
-  Uint32List get dataAsUint32List {
+  Uint8List get dataAsUint8List {
     var imageData = data as img.ImageDataUint8;
     var dataUint8 = imageData.data;
-    return dataUint8.buffer
-        .asUint32List(dataUint8.offsetInBytes, dataUint8.length ~/ 4);
+    return dataUint8;
   }
 }
 

--- a/lib/src/pcanvas_bitmap.dart
+++ b/lib/src/pcanvas_bitmap.dart
@@ -20,9 +20,42 @@ class PCanvasBitmap extends PCanvas {
 
   late final img.Image _bitmap;
 
-  PCanvasBitmap(this.width, this.height, this.painter) : super.impl() {
-    _bitmap = img.Image(width, height);
+  PCanvasBitmap(this.width, this.height, this.painter,
+      {PCanvasPixels? initialPixels})
+      : super.impl() {
+    _bitmap = img.Image(
+        width: width,
+        height: height,
+        format: img.Format.uint8,
+        numChannels: 4,
+        withPalette: false);
+
+    if (initialPixels != null) {
+      setPixels(initialPixels);
+    }
+
     painter.callLoadResources(this);
+  }
+
+  @override
+  void setPixels(PCanvasPixels pixels,
+      {int x = 0, int y = 0, int? width, int? height}) {
+    var w = width ?? this.width;
+    if (x + w > this.width) w = this.width - x;
+
+    var h = height ?? this.height;
+    if (y + h > this.height) h = this.height - y;
+
+    if (w <= 0 || h <= 0) return;
+
+    pixels = pixels.toPCanvasPixelsABGR();
+
+    for (var y1 = 0; y1 < h; ++y1) {
+      for (var x1 = 0; x1 < w; ++x1) {
+        var p = pixels.getImageColor(x, y);
+        _bitmap.setPixel(x + x1, y + y1, p);
+      }
+    }
   }
 
   @override
@@ -67,6 +100,19 @@ class PCanvasBitmap extends PCanvas {
   }
 
   @override
+  PCanvasStateExtra? get stateExtra => null;
+
+  PRectangle? _clip;
+
+  @override
+  PRectangle? get clip => _clip;
+
+  @override
+  set clip(PRectangle? clip) {
+    _clip = clip;
+  }
+
+  @override
   Object get canvasNative => _bitmap;
 
   int _imageIdCount = 0;
@@ -86,7 +132,8 @@ class PCanvasBitmap extends PCanvas {
             .getUri(uri, options: Options(responseType: ResponseType.bytes))
             .then((response) {
           var bytes = response.data as List<int>;
-          return img.decodeImage(bytes)!;
+          var data = bytes is Uint8List ? bytes : Uint8List.fromList(bytes);
+          return img.decodeImage(data)!;
         });
 
         return _PCanvasImageMemoryAsync('img_$id', imageFuture, '$uri');
@@ -98,6 +145,24 @@ class PCanvasBitmap extends PCanvas {
 
   @override
   void clearRect(num x, num y, num width, num height, {PStyle? style}) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+
+    if (clip != null) {
+      var r = clip.intersection(PRectangle(x, y, width, height));
+
+      if (r.isZeroDimension) {
+        return;
+      }
+
+      x = r.x;
+      y = r.y;
+      width = r.width;
+      height = r.height;
+    }
+
     var color = style?.color ?? PColor.colorWhite;
     fillRect(x, y, width, height, PStyle(color: color));
   }
@@ -106,9 +171,28 @@ class PCanvasBitmap extends PCanvas {
   void drawImage(PCanvasImage image, num x, num y) {
     checkImageLoaded(image);
 
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var imgW = image.width;
+      var imgH = image.height;
+
+      var box = PRectangle(x, y, imgW, imgH);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      if (r.width != imgW || r.height != imgH) {
+        drawImageArea(image, 0, 0, imgW, imgH, x, y, imgW, imgH);
+        return;
+      }
+    }
+
     if (image is PCanvasImageMemory) {
       var srcImg = image.image;
-      img.drawImage(
+
+      img.compositeImage(
         _bitmap,
         srcImg,
         srcX: 0,
@@ -130,9 +214,25 @@ class PCanvasBitmap extends PCanvas {
       PCanvasImage image, num x, num y, num width, num height) {
     checkImageLoaded(image);
 
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var box = PRectangle(x, y, width, height);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      if (r.width != width || r.height != height) {
+        drawImageArea(
+            image, 0, 0, image.width, image.height, x, y, width, height);
+        return;
+      }
+    }
+
     if (image is PCanvasImageMemory) {
       var srcImg = image.image;
-      img.drawImage(
+      img.compositeImage(
         _bitmap,
         srcImg,
         srcX: 0,
@@ -154,9 +254,37 @@ class PCanvasBitmap extends PCanvas {
       int srcHeight, num dstX, num dstY, num dstWidth, num dstHeight) {
     checkImageLoaded(image);
 
+    dstX = transform.x(dstX);
+    dstY = transform.y(dstY);
+
+    var clip = _clip;
+    if (clip != null) {
+      var box = PRectangle(dstX, dstY, dstWidth, dstHeight);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      if (r.width != dstWidth || r.height != dstHeight) {
+        var imgW = image.width;
+        var imgH = image.height;
+
+        var rW = (imgW / dstWidth);
+        var rH = (imgH / dstHeight);
+
+        srcX = ((r.x - dstX) * rW).toInt();
+        srcY = ((r.y - dstY) * rH).toInt();
+        srcWidth = (r.width * rW).toInt();
+        srcHeight = (r.height * rH).toInt();
+
+        dstX = r.x.toInt();
+        dstY = r.y.toInt();
+        dstWidth = r.width.toInt();
+        dstHeight = r.height.toInt();
+      }
+    }
+
     if (image is PCanvasImageMemory) {
       var srcImg = image.image;
-      img.drawImage(
+      img.compositeImage(
         _bitmap,
         srcImg,
         srcX: srcX.toInt(),
@@ -175,25 +303,86 @@ class PCanvasBitmap extends PCanvas {
 
   @override
   void strokeRect(num x, num y, num width, num height, PStyle style) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var box = PRectangle(x, y, width, height);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      x = r.x;
+      y = r.y;
+      width = r.width;
+      height = r.height;
+    }
+
+    if (width <= 0 || height <= 0) return;
+
     var color = style.color ?? PColor.colorGrey;
     var size = style.size ?? 1;
 
-    _strokeRect(_bitmap, x.toInt(), y.toInt(), (x + width).toInt(),
-        (y + height).toInt(), color.rgba32,
-        thickness: size);
+    var x1 = x.toInt();
+    var y1 = y.toInt();
+
+    var x2 = x1 + width.toInt();
+    var y2 = y1 + height.toInt();
+
+    _strokeRect(_bitmap, x1, y1, x2, y2, color.imageColor, thickness: size);
   }
 
   @override
   void fillRect(num x, num y, num width, num height, PStyle style) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var box = PRectangle(x, y, width, height);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      x = r.x;
+      y = r.y;
+      width = r.width;
+      height = r.height;
+    }
+
+    if (width <= 0 || height <= 0) return;
+
+    var x2 = (x + width).toInt() - 1;
+    var y2 = (y + height).toInt() - 1;
+
     var color = style.color ?? PColor.colorGrey;
 
-    img.fillRect(_bitmap, x.toInt(), y.toInt(), (x + width).toInt(),
-        (y + height).toInt(), color.rgba32);
+    img.fillRect(_bitmap,
+        x1: x.toInt(), y1: y.toInt(), x2: x2, y2: y2, color: color.imageColor);
   }
 
   @override
   void strokeCircle(num x, num y, num radius, PStyle style,
       {num startAngle = 0, num endAngle = 360}) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var w = radius * 2;
+
+      var box = PRectangle(x, y, w, w);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      _callClipped(clip, box,
+          () => _strokeCircleImpl(x, y, radius, style, startAngle, endAngle));
+    } else {
+      _strokeCircleImpl(x, y, radius, style, startAngle, endAngle);
+    }
+  }
+
+  void _strokeCircleImpl(
+      num x, num y, num radius, PStyle style, num startAngle, num endAngle) {
     x = canvasX(x);
     y = canvasY(y);
     radius = canvasX(radius);
@@ -201,8 +390,11 @@ class PCanvasBitmap extends PCanvas {
 
     if ((startAngle == 0 && endAngle == 360) ||
         (startAngle == 360 && endAngle == 0)) {
-      img.drawCircle(
-          _bitmap, x.toInt(), y.toInt(), radius.toInt(), color.rgba32);
+      img.drawCircle(_bitmap,
+          x: x.toInt(),
+          y: y.toInt(),
+          radius: radius.toInt(),
+          color: color.imageColor);
     } else {
       throw UnsupportedError(
           "Only `startAngle = 0` and `endAngle = 360` are suported.");
@@ -212,6 +404,26 @@ class PCanvasBitmap extends PCanvas {
   @override
   void fillCircle(num x, num y, num radius, PStyle style,
       {num startAngle = 0, num endAngle = 360}) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var w = radius * 2;
+
+      var box = PRectangle(x, y, w, w);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      _callClipped(clip, box,
+          () => _fillCircleImpl(x, y, radius, style, startAngle, endAngle));
+    } else {
+      _fillCircleImpl(x, y, radius, style, startAngle, endAngle);
+    }
+  }
+
+  void _fillCircleImpl(
+      num x, num y, num radius, PStyle style, num startAngle, num endAngle) {
     x = canvasX(x);
     y = canvasY(y);
     radius = canvasX(radius);
@@ -219,8 +431,11 @@ class PCanvasBitmap extends PCanvas {
 
     if ((startAngle == 0 && endAngle == 360) ||
         (startAngle == 360 && endAngle == 0)) {
-      img.fillCircle(
-          _bitmap, x.toInt(), y.toInt(), radius.toInt(), color.rgba32);
+      img.fillCircle(_bitmap,
+          x: x.toInt(),
+          y: y.toInt(),
+          radius: radius.toInt(),
+          color: color.imageColor);
     } else {
       throw UnsupportedError(
           "Only `startAngle = 0` and `endAngle = 360` are suported.");
@@ -230,6 +445,21 @@ class PCanvasBitmap extends PCanvas {
   @override
   void fillTopDownGradient(
       num x, num y, num width, num height, PColor colorFrom, PColor colorTo) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var box = PRectangle(x, y, width, height);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      x = r.x;
+      y = r.y;
+      width = r.width;
+      height = r.height;
+    }
+
     var cFrom = colorFrom.toPColorRGBA();
     var cTo = colorTo.toPColorRGBA();
 
@@ -290,6 +520,21 @@ class PCanvasBitmap extends PCanvas {
   @override
   void fillLeftRightGradient(
       num x, num y, num width, num height, PColor colorFrom, PColor colorTo) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var box = PRectangle(x, y, width, height);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      x = r.x;
+      y = r.y;
+      width = r.width;
+      height = r.height;
+    }
+
     var cFrom = colorFrom.toPColorRGBA();
     var cTo = colorTo.toPColorRGBA();
 
@@ -360,7 +605,7 @@ class PCanvasBitmap extends PCanvas {
       w += x;
     }
 
-    var h = img.findStringHeight(bitmapFont, text);
+    var h = _findStringHeight(bitmapFont, text);
 
     return PTextMetric(w, h);
   }
@@ -374,20 +619,41 @@ class PCanvasBitmap extends PCanvas {
     if (bitmapCharacter == null) {
       return bitmapFont.base ~/ 2;
     } else {
-      return bitmapCharacter.xadvance;
+      return bitmapCharacter.xAdvance;
     }
   }
 
   @override
   void drawText(String text, num x, num y, PFont font, PStyle style) {
+    x = transform.x(x);
+    y = transform.y(y);
+
+    var clip = _clip;
+    if (clip != null) {
+      var m = measureText(text, font);
+
+      var box = PRectangle(x, y, m.actualWidth, m.actualHeight);
+      var r = clip.intersection(box);
+      if (r.isZeroDimension) return;
+
+      _callClipped(clip, box, () => _drawTextImpl(style, font, x, y, text));
+    } else {
+      _drawTextImpl(style, font, x, y, text);
+    }
+  }
+
+  void _drawTextImpl(PStyle style, PFont font, num x, num y, String text) {
     var color = style.color ?? PColor.colorGrey;
     var bitmapFont = font.toBitmapFont();
-    img.drawString(_bitmap, bitmapFont, x.toInt(), y.toInt(), text,
-        color: color.rgba32);
+    img.drawString(_bitmap, text,
+        font: bitmapFont, x: x.toInt(), y: y.toInt(), color: color.imageColor);
   }
 
   @override
   void fillPath(List path, PStyle style, {bool closePath = false}) {
+    var points = _toPoints(path, closePath);
+    if (points.length < 2) return;
+
     throw UnimplementedError();
   }
 
@@ -396,8 +662,21 @@ class PCanvasBitmap extends PCanvas {
     var points = _toPoints(path, closePath);
     if (points.length < 2) return;
 
+    var clip = _clip;
+    if (clip != null) {
+      var box = points.boundingBox;
+
+      if (box == null || !clip.containsRectangle(box)) return;
+
+      _callClipped(clip, box, () => _strokePathImpl(points, style));
+    } else {
+      _strokePathImpl(points, style);
+    }
+  }
+
+  void _strokePathImpl(List<Point> points, PStyle style) {
     var color = style.color ?? PColor.colorBlack;
-    var c = color.rgba32;
+    var c = color.imageColor;
 
     for (var i = 1; i < points.length; ++i) {
       var p1 = points[i - 1];
@@ -409,8 +688,37 @@ class PCanvasBitmap extends PCanvas {
       var x2 = p2.x.toInt();
       var y2 = p2.y.toInt();
 
-      img.drawLine(_bitmap, x1, y1, x2, y2, c);
+      img.drawLine(_bitmap, x1: x1, y1: y1, x2: x2, y2: y2, color: c);
     }
+  }
+
+  /// Performs a paint in the [paintRect] applying a [clip] rectangle.
+  /// - The paint operations performed by the [call] [Function] must not exceed the clip rectangle.
+  R? _callClipped<R>(PRectangle clip, PRectangle paintRect, R Function() call) {
+    var imgRect = PRectangle(0, 0, width, height);
+
+    clip = imgRect.intersection(clip);
+    if (clip.isZeroDimension) return null;
+
+    paintRect = imgRect.intersection(paintRect);
+    if (paintRect.isZeroDimension) return null;
+
+    var paintRectClipped = clip.intersection(paintRect);
+    if (paintRectClipped.isZeroDimension) return null;
+
+    var pixels =
+        PCanvasPixelsABGR.fromPixels(width, height, _bitmap.dataAsUint32List);
+
+    var cp1 = pixels.copyRectangle(paintRect)!;
+
+    var ret = call();
+
+    var cp2 = pixels.copyRectangle(paintRectClipped)!;
+
+    pixels.putPixels(cp1, paintRect.x, paintRect.y);
+    pixels.putPixels(cp2, paintRectClipped.x, paintRectClipped.y);
+
+    return ret;
   }
 
   List<Point> _toPoints(List<dynamic> path, bool closePath) {
@@ -422,8 +730,11 @@ class PCanvasBitmap extends PCanvas {
       if (e is num) {
         var x = e;
         var y = path[++i];
+        x = transform.x(x);
+        y = transform.y(y);
         points.add(Point(x, y));
       } else if (e is Point) {
+        e = transform.point(e);
         points.add(e);
       }
     }
@@ -441,15 +752,11 @@ class PCanvasBitmap extends PCanvas {
   }
 
   @override
-  PCanvasPixels get pixels {
-    return PCanvasPixelsABGR(width, height, Uint32List.fromList(_bitmap.data));
-  }
+  PCanvasPixels get pixels =>
+      PCanvasPixelsABGR.fromPixels(width, height, _bitmap.dataAsUint32List);
 
   @override
-  FutureOr<Uint8List> toPNG() {
-    var bytes = img.encodePng(_bitmap);
-    return bytes is Uint8List ? bytes : Uint8List.fromList(bytes);
-  }
+  FutureOr<Uint8List> toPNG() => img.encodePng(_bitmap);
 
   @override
   String toString() {
@@ -458,34 +765,64 @@ class PCanvasBitmap extends PCanvas {
 }
 
 extension _PColorExtension on PColor {
-  int get rgba32 {
+  img.Color get imageColor {
     var c = this;
 
     if (c is PColorRGBA && c.hasAlpha) {
-      return img.getColor(c.r, c.g, c.b, c.a);
+      return img.ColorUint8.rgba(c.r, c.g, c.b, c.a);
     } else if (c is PColorRGB) {
-      return img.getColor(c.r, c.g, c.b);
+      return img.ColorUint8.rgb(c.r, c.g, c.b);
     } else {
       throw StateError("Can't handle color type `${c.runtimeType}`: $c");
     }
   }
 }
 
-void _strokeRect(img.Image dst, int x1, int y1, int x2, int y2, int color,
+void _strokeRect(img.Image dst, int x1, int y1, int x2, int y2, img.Color color,
     {bool antialias = true, num thickness = 1}) {
+  var thicknessHalf = thickness ~/ 2;
+  var fix = thickness % 2 == 0 ? 0 : 1;
+
   final x0 = math.min(x1, x2);
   final y0 = math.min(y1, y2);
   x1 = math.max(x1, x2);
   y1 = math.max(y1, y2);
 
-  img.drawLine(dst, x0, y0, x1, y0, color,
-      antialias: antialias, thickness: thickness);
-  img.drawLine(dst, x1, y0, x1, y1, color,
-      antialias: antialias, thickness: thickness);
-  img.drawLine(dst, x0, y1, x1, y1, color,
-      antialias: antialias, thickness: thickness);
-  img.drawLine(dst, x0, y0, x0, y1, color,
-      antialias: antialias, thickness: thickness);
+  img.drawLine(dst,
+      x1: x0 - thicknessHalf,
+      y1: y0,
+      x2: x1 + thicknessHalf - 1,
+      y2: y0,
+      color: color,
+      antialias: antialias,
+      thickness: thickness);
+
+  img.drawLine(dst,
+      x1: x0 - thicknessHalf,
+      y1: y1 - fix,
+      x2: x1 + thicknessHalf - 1,
+      y2: y1 - fix,
+      color: color,
+      antialias: antialias,
+      thickness: thickness);
+
+  img.drawLine(dst,
+      x1: x0,
+      y1: y0 + thicknessHalf,
+      x2: x0,
+      y2: y1 - thicknessHalf - fix,
+      color: color,
+      antialias: antialias,
+      thickness: thickness);
+
+  img.drawLine(dst,
+      x1: x1 - fix,
+      y1: y0 + thicknessHalf,
+      x2: x1 - fix,
+      y2: y1 - thicknessHalf - fix,
+      color: color,
+      antialias: antialias,
+      thickness: thickness);
 }
 
 abstract class PCanvasImageMemory extends PCanvasImage {
@@ -572,11 +909,11 @@ class _PCanvasImageMemoryAsync extends PCanvasImageMemory {
 extension _PFontExtension on PFont {
   img.BitmapFont toBitmapFontFamily() {
     if (size >= 36) {
-      return img.arial_48;
+      return img.arial48;
     } else if (size >= 19) {
-      return img.arial_24;
+      return img.arial24;
     } else {
-      return img.arial_14;
+      return img.arial14;
     }
   }
 
@@ -587,4 +924,63 @@ extension _PFontExtension on PFont {
     f.antialias = true;
     return f;
   }
+}
+
+extension _PCanvasPixelsExtension on PCanvasPixels {
+  img.Color getImageColor(int x, int y) {
+    var pixels = this;
+
+    var p = pixels.pixel(x, y);
+
+    int r, g, b, a;
+
+    if (pixels is PCanvasPixelsRGBA) {
+      r = (p >> 24) & 0xff;
+      g = (p >> 16) & 0xff;
+      b = (p >> 8) & 0xff;
+      a = ((p) & 0xff);
+    } else if (pixels is PCanvasPixelsARGB) {
+      r = (p >> 16) & 0xff;
+      g = (p >> 8) & 0xff;
+      b = (p) & 0xff;
+      a = ((p >> 24) & 0xff);
+    } else if (pixels is PCanvasPixelsABGR) {
+      r = (p) & 0xff;
+      g = (p >> 8) & 0xff;
+      b = (p >> 16) & 0xff;
+      a = ((p >> 24) & 0xff);
+    } else {
+      throw StateError("Can't pixels type: ${pixels.runtimeType} > $pixels");
+    }
+
+    return img.ColorUint32.rgba(r, g, b, a);
+  }
+}
+
+extension _ImageExtension on img.Image {
+  Uint32List get dataAsUint32List {
+    var imageData = data as img.ImageDataUint8;
+    var dataUint8 = imageData.data;
+    return dataUint8.buffer
+        .asUint32List(dataUint8.offsetInBytes, dataUint8.length ~/ 4);
+  }
+}
+
+// From package `image 3.3.0`.
+int _findStringHeight(img.BitmapFont font, String string) {
+  var stringHeight = 0;
+  final chars = string.codeUnits;
+
+  for (var c in chars) {
+    if (!font.characters.containsKey(c)) {
+      continue;
+    }
+    final ch = font.characters[c]!;
+
+    if (ch.height + ch.yOffset > stringHeight) {
+      stringHeight = ch.height + ch.yOffset;
+    }
+  }
+
+  return (stringHeight * 1.05).round();
 }

--- a/lib/src/pcanvas_element.dart
+++ b/lib/src/pcanvas_element.dart
@@ -1,15 +1,281 @@
+import 'dart:collection';
+
 import 'pcanvas_base.dart';
 
 /// A base class for [PCanvas] elements.
 abstract class PCanvasElement {
+  /// The ID of this element.
+  String? id;
+
+  PCanvasElement({this.id});
+
   /// The bounding box of this element.
-  PRectangle getBoundingBox(PCanvas pCanvas);
+  PRectangle get boundingBox;
+
+  /// The dimension this element.
+  PDimension get dimension => boundingBox;
+
+  /// The bounding box of the painted area of this element.
+  PRectangle getPaintBoundingBox(PCanvas pCanvas);
 
   /// The Z index of this element.
   int? get zIndex;
 
   /// The paint operation of this element.
   void paint(PCanvas pCanvas);
+}
+
+/// Mixin for a class that is a container for [PCanvasElement].
+mixin PCanvasElementContainer<E extends PCanvasElement> {
+  /// All the [PCanvasElement]s of this instance.
+  UnmodifiableListView<E> get elements;
+
+  /// Returns `true` if this isntances has [elements].
+  bool get hasElements;
+
+  /// Clears the [elements] of this instance.
+  void clearElements();
+
+  /// Adds an [element] to this instances.
+  void addElement(E element);
+
+  /// Removes [element] from this instance.
+  bool removeElement(E element);
+
+  /// Adds all the entries in [elements] to this instances.
+  void addAllElements(Iterable<E> elements) {
+    for (var e in elements) {
+      addElement(e);
+    }
+  }
+
+  /// Removes all entries in [elements] from this instances.
+  void removeAllElements(Iterable<E> elements) {
+    for (var e in elements) {
+      removeElement(e);
+    }
+  }
+
+  /// Returns a list of [PCanvasElement] of type [T] with a matching [id].
+  List<T> selectElementByID<T extends PCanvasElement>(String? id,
+      {bool recursive = false}) {
+    var elements = this.elements;
+
+    var sel = elements.whereType<T>().where((e) => e.id == id).toList();
+
+    if (!recursive) {
+      return sel;
+    }
+
+    var subList = elements
+        .whereType<PCanvasElementContainer>()
+        .expand((e) => e.selectElementByID<T>(id, recursive: true))
+        .toList();
+
+    return [...sel, ...subList];
+  }
+
+  /// Returns a list of [PCanvasElement] of type [T].
+  List<T> selectElementByType<T extends PCanvasElement>(
+      {bool recursive = false}) {
+    var elements = this.elements;
+
+    var sel = elements.whereType<T>().toList();
+
+    if (!recursive) {
+      return sel;
+    }
+
+    var subList = elements
+        .whereType<PCanvasElementContainer>()
+        .expand((e) => e.selectElementByType<T>(recursive: true))
+        .toList();
+
+    return [...sel, ...subList];
+  }
+
+  /// Returns a list of [PCanvasElement] of type [T] filteted by [selector].
+  List<T> selectElementWhere<T extends PCanvasElement>(
+      bool Function(T elem) selector,
+      {bool recursive = false}) {
+    var elements = this.elements;
+
+    var sel = elements.whereType<T>().where(selector).toList();
+
+    if (!recursive) {
+      return sel;
+    }
+
+    var subList = elements
+        .whereType<PCanvasElementContainer>()
+        .expand((e) => e.selectElementWhere<T>(selector, recursive: true))
+        .toList();
+
+    return [...sel, ...subList];
+  }
+}
+
+abstract class PCanvasElement2D extends PCanvasElement {
+  /// The parent of this 2D element.
+  PCanvasElementContainer? get parent;
+
+  PCanvasElement2D({super.id}) : super();
+
+  /// The resolved X coordinate of this 2D element.
+  num get x;
+
+  /// The resolved Y coordinate of this 2D element.
+  num get y;
+
+  /// The resolved width of this 2D element.
+  num get width;
+
+  /// The resolved height of this 2D element.
+  num get height;
+}
+
+abstract class PCanvasElement2DBase extends PCanvasElement2D {
+  @override
+  PCanvasElementContainer? parent;
+
+  /// The position of this element.
+  Position position;
+
+  /// The dimension of this element.
+  @override
+  PDimension dimension;
+
+  @override
+  int? zIndex;
+
+  PCanvasElement2DBase({
+    this.parent,
+    this.zIndex,
+    super.id,
+    Position? pos,
+    num? x,
+    num? y,
+    PDimension? dimension,
+    num? width,
+    num? height,
+  })  : position = _resolvePosition(pos, x, y),
+        dimension = _resolveDimension(dimension, width, height),
+        super();
+
+  static Position _resolvePosition(Position? pos, num? x, num? y) {
+    if (pos != null) return pos;
+
+    if (x == null || y == null) {
+      throw ArgumentError("Invalid position coordinate> x: $x ; y: $y");
+    }
+
+    return Point(x, y);
+  }
+
+  static PDimension _resolveDimension(PDimension? dimension, num? w, num? h) {
+    if (dimension != null) return dimension;
+
+    if (w == null || h == null) {
+      throw ArgumentError("Invalid dimension> width: $w ; height: $h");
+    }
+
+    return PDimension(w, h);
+  }
+
+  @override
+  num get x => position.x;
+
+  void set(num x) => position = position;
+
+  @override
+  num get y => position.y;
+
+  @override
+  num get width => dimension.width;
+
+  @override
+  num get height => dimension.height;
+
+  @override
+  PRectangle get boundingBox => PRectangle(x, y, width, height);
+
+  @override
+  PRectangle getPaintBoundingBox(PCanvas pCanvas) => PRectangle(
+      pCanvas.canvasX(x),
+      pCanvas.canvasX(y),
+      pCanvas.canvasX(width),
+      pCanvas.canvasX(height));
+}
+
+class PCanvasPanel2D extends PCanvasElement2DBase
+    with PCanvasElementContainer<PCanvasElement2D> {
+  PStyle? style;
+
+  PCanvasPanel2D({
+    this.style,
+    super.parent,
+    super.zIndex,
+    super.id,
+    super.pos,
+    super.x,
+    super.y,
+    super.dimension,
+    super.width,
+    super.height,
+  }) : super();
+
+  final List<PCanvasElement2D> _elements = <PCanvasElement2D>[];
+
+  @override
+  UnmodifiableListView<PCanvasElement2D> get elements =>
+      UnmodifiableListView<PCanvasElement2D>(_elements);
+
+  @override
+  bool get hasElements => _elements.isNotEmpty;
+
+  @override
+  void clearElements() => _elements.clear();
+
+  @override
+  void addElement(PCanvasElement2D element) => _elements.add(element);
+
+  @override
+  bool removeElement(PCanvasElement2D element) => _elements.remove(element);
+
+  @override
+  void paint(PCanvas pCanvas) {
+    var prevState = pCanvas.saveState();
+
+    var panelT = PcanvasTransform(translateX: x, translateY: y);
+    var prevT = pCanvas.transform;
+
+    var boundingBox = this.boundingBox.transform(prevT);
+
+    pCanvas.subTransform = panelT;
+
+    try {
+      pCanvas.subClip = boundingBox;
+
+      var style = this.style;
+      if (style != null) {
+        pCanvas.fillRect(0, 0, width, height, style);
+      }
+
+      var paintRect = dimension.toPRectangle();
+
+      for (var e in elements) {
+        var eBox = e.boundingBox;
+
+        if (!paintRect.intersectsRectangle(eBox)) {
+          continue;
+        }
+
+        e.paint(pCanvas);
+      }
+    } finally {
+      pCanvas.restoreState(expectedState: prevState);
+    }
+  }
 }
 
 extension PCanvasElementExtension on List<PCanvasElement> {
@@ -19,4 +285,30 @@ extension PCanvasElementExtension on List<PCanvasElement> {
         var z2 = b.zIndex ?? 0;
         return z1.compareTo(z2);
       });
+}
+
+/// A rectangle [PCanvasElement2D].
+class PRectangleElement extends PCanvasElement2DBase {
+  PStyle? style;
+
+  PRectangleElement({
+    this.style,
+    super.parent,
+    super.zIndex,
+    super.id,
+    super.pos,
+    super.x,
+    super.y,
+    super.dimension,
+    super.width,
+    super.height,
+  });
+
+  @override
+  void paint(PCanvas pCanvas) {
+    var style = this.style;
+    if (style != null) {
+      pCanvas.fillRect(x, y, width, height, style);
+    }
+  }
 }

--- a/lib/src/pcanvas_html.dart
+++ b/lib/src/pcanvas_html.dart
@@ -679,11 +679,8 @@ class PCanvasHTML extends PCanvas {
 
     var imageData = _ctx.getImageData(0, 0, w, h);
 
-    var data = imageData.data.buffer.asUint32List(
-        imageData.data.offsetInBytes, (imageData.width * imageData.height));
-
-    return PCanvasPixelsABGR.fromPixels(
-        imageData.width, imageData.height, data);
+    return PCanvasPixelsABGR.fromBytes(
+        imageData.width, imageData.height, imageData.data);
   }
 
   @override

--- a/lib/src/pcanvas_impl_bitmap.dart
+++ b/lib/src/pcanvas_impl_bitmap.dart
@@ -1,5 +1,6 @@
 import 'pcanvas_base.dart';
 import 'pcanvas_bitmap.dart';
 
-PCanvas createPCanvasImpl(int width, int height, PCanvasPainter painter) =>
-    PCanvasBitmap(width, height, painter);
+PCanvas createPCanvasImpl(int width, int height, PCanvasPainter painter,
+        {PCanvasPixels? initialPixels}) =>
+    PCanvasBitmap(width, height, painter, initialPixels: initialPixels);

--- a/lib/src/pcanvas_impl_html.dart
+++ b/lib/src/pcanvas_impl_html.dart
@@ -1,5 +1,6 @@
 import 'pcanvas_base.dart';
 import 'pcanvas_html.dart';
 
-PCanvas createPCanvasImpl(int width, int height, PCanvasPainter painter) =>
-    PCanvasHTML(width, height, painter);
+PCanvas createPCanvasImpl(int width, int height, PCanvasPainter painter,
+        {PCanvasPixels? initialPixels}) =>
+    PCanvasHTML(width, height, painter, initialPixels: initialPixels);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,18 @@
 name: pcanvas
 description: A portable canvas that can work in many platforms (Flutter, Web, Desktop, in-memory Image).
-version: 1.0.5
+version: 1.0.6
 homepage: https://github.com/gmpassos/pcanvas
 
 environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
+  collection: ^1.16.0
   dio: ^4.0.6
-  image: ^3.2.2
+  image: ^4.0.7
 
 dev_dependencies:
   lints: ^2.0.1
-  test: ^1.22.0
+  test: ^1.22.1
   dependency_validator: ^3.2.2
   coverage: ^1.6.1

--- a/test/pcanvas_test.dart
+++ b/test/pcanvas_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:pcanvas/pcanvas.dart';
 import 'package:test/test.dart';
@@ -51,6 +52,39 @@ void main() {
         expect(d.area, equals(0));
         expect(d.center, equals(Point(5, 0)));
         expect(d.isZeroDimension, isTrue);
+      }
+    });
+
+    test('PCanvas.pixels', () async {
+      var pCanvas = PCanvas(3, 3, MyPainterChannels());
+
+      print(pCanvas);
+
+      print(
+          'Endian.host: ${Endian.host == Endian.big ? 'big' : 'little'}-endian');
+
+      await pCanvas.waitLoading();
+      await pCanvas.callPainter();
+
+      expect(pCanvas.painter.isLoadingResources, isFalse);
+
+      expect(pCanvas.width, equals(3));
+      expect(pCanvas.height, equals(3));
+
+      print(pCanvas.toDataUrl());
+
+      var pixels = await pCanvas.pixels;
+
+      print(pixels);
+
+      expect(pixels.length, equals(3 * 3));
+
+      {
+        var c = pixels.pixelColor(0, 0);
+        expect(c.r, equals(1));
+        expect(c.g, equals(2));
+        expect(c.b, equals(3));
+        expect(c.a, equals(255));
       }
     });
 
@@ -640,6 +674,14 @@ Future<void> _checkDataUrl(PCanvas pCanvas, String title) async {
   var dataUrl = await pCanvas.toDataUrl();
   print(dataUrl);
   expect(dataUrl, startsWith('data:image/png;base64,iV'));
+}
+
+class MyPainterChannels extends PCanvasPainter {
+  @override
+  FutureOr<bool> paint(PCanvas pCanvas) {
+    pCanvas.clear(style: PStyle(color: PColorRGBA(01, 02, 03, 1)));
+    return true;
+  }
 }
 
 class MyPainterFlood1 extends PCanvasPainter {


### PR DESCRIPTION
- `PCanvas`:
  - Constructor: added parameter `initialPixels`.
  - Added method `setPixels`.
  - Added support for `clip` and `subClip`.
  - Added `transform`: new `PcanvasTransform` class.
  - Added `saveState`, `restoreState` and `callWithGuardedState`.
  - `elements` now is unmmodifiable.
- `PCanvasPixels`:
  - Added `setPixel`, `setPixelFrom`, `setPixelsLineFrom`, `setPixelsColumnFrom` and `setPixelsRectFrom`.
  - Added `putPixels`, `copyRectangle` and `copyRect`.
  - Added `toPCanvas`, `toPNG` and `toDataUrl`.
- New `PCanvasElementContainer`:
  - New `PCanvasPanel2D` and `PRectangleElement`.
- `PRectangle`:
  - Added `intersectsRectangle`, `intersects` and `intersection`.
  - Added `containsRectangle`, `contains`, `containsPoint` and `containsXY`.
  - Added `transform`.
- image: ^4.0.7
- test: ^1.22.1
- collection: ^1.16.0