### PR TITLE
v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.7
+
+- `PCanvasPainter`:
+  - Added `zIndex` to define the painter layer. Previously was fixed to `0`.
+- Added `PCanvasFactory`:
+  - Allows extra platform dependent implementations:
+    - `pixelsToPNG` and `pixelsToDataUrl`
+- `PCanvasBitmap.toPNG`:
+  - Ensure `singleFrame: true`
+
 ## 1.0.6
 
 - `PCanvas`:

--- a/lib/src/pcanvas_bitmap.dart
+++ b/lib/src/pcanvas_bitmap.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:image/image.dart' as img;
 
 import 'pcanvas_base.dart';
+import 'pcanvas_bitmap_extension.dart';
 
 /// An in-memory [PCanvas] implementation.
 class PCanvasBitmap extends PCanvas {
@@ -754,7 +755,7 @@ class PCanvasBitmap extends PCanvas {
       PCanvasPixelsABGR.fromBytes(width, height, _bitmap.dataAsUint8List);
 
   @override
-  FutureOr<Uint8List> toPNG() => img.encodePng(_bitmap);
+  FutureOr<Uint8List> toPNG() => img.encodePng(_bitmap, singleFrame: true);
 
   @override
   String toString() {
@@ -901,65 +902,6 @@ class _PCanvasImageMemoryAsync extends PCanvasImageMemory {
       _loading = null;
       return true;
     });
-  }
-}
-
-extension _PFontExtension on PFont {
-  img.BitmapFont toBitmapFontFamily() {
-    if (size >= 36) {
-      return img.arial48;
-    } else if (size >= 19) {
-      return img.arial24;
-    } else {
-      return img.arial14;
-    }
-  }
-
-  img.BitmapFont toBitmapFont() {
-    var f = toBitmapFontFamily();
-    if (bold) f.bold = true;
-    if (italic) f.italic = true;
-    f.antialias = true;
-    return f;
-  }
-}
-
-extension _PCanvasPixelsExtension on PCanvasPixels {
-  img.Color getImageColor(int x, int y) {
-    var pixels = this;
-
-    var p = pixels.pixel(x, y);
-
-    int r, g, b, a;
-
-    if (pixels is PCanvasPixelsRGBA) {
-      r = (p >> 24) & 0xff;
-      g = (p >> 16) & 0xff;
-      b = (p >> 8) & 0xff;
-      a = ((p) & 0xff);
-    } else if (pixels is PCanvasPixelsARGB) {
-      r = (p >> 16) & 0xff;
-      g = (p >> 8) & 0xff;
-      b = (p) & 0xff;
-      a = ((p >> 24) & 0xff);
-    } else if (pixels is PCanvasPixelsABGR) {
-      r = (p) & 0xff;
-      g = (p >> 8) & 0xff;
-      b = (p >> 16) & 0xff;
-      a = ((p >> 24) & 0xff);
-    } else {
-      throw StateError("Can't pixels type: ${pixels.runtimeType} > $pixels");
-    }
-
-    return img.ColorUint32.rgba(r, g, b, a);
-  }
-}
-
-extension _ImageExtension on img.Image {
-  Uint8List get dataAsUint8List {
-    var imageData = data as img.ImageDataUint8;
-    var dataUint8 = imageData.data;
-    return dataUint8;
   }
 }
 

--- a/lib/src/pcanvas_bitmap_extension.dart
+++ b/lib/src/pcanvas_bitmap_extension.dart
@@ -1,0 +1,87 @@
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
+
+import 'pcanvas_base.dart';
+
+extension PFontExtension on PFont {
+  img.BitmapFont toBitmapFontFamily() {
+    if (size >= 36) {
+      return img.arial48;
+    } else if (size >= 19) {
+      return img.arial24;
+    } else {
+      return img.arial14;
+    }
+  }
+
+  img.BitmapFont toBitmapFont() {
+    var f = toBitmapFontFamily();
+    if (bold) f.bold = true;
+    if (italic) f.italic = true;
+    f.antialias = true;
+    return f;
+  }
+}
+
+extension PCanvasPixelsExtension on PCanvasPixels {
+  img.Color getImageColor(int x, int y) {
+    var pixels = this;
+
+    var p = pixels.pixel(x, y);
+
+    int r, g, b, a;
+
+    if (pixels is PCanvasPixelsRGBA) {
+      r = (p >> 24) & 0xff;
+      g = (p >> 16) & 0xff;
+      b = (p >> 8) & 0xff;
+      a = ((p) & 0xff);
+    } else if (pixels is PCanvasPixelsARGB) {
+      r = (p >> 16) & 0xff;
+      g = (p >> 8) & 0xff;
+      b = (p) & 0xff;
+      a = ((p >> 24) & 0xff);
+    } else if (pixels is PCanvasPixelsABGR) {
+      r = (p) & 0xff;
+      g = (p >> 8) & 0xff;
+      b = (p >> 16) & 0xff;
+      a = ((p >> 24) & 0xff);
+    } else {
+      throw StateError("Can't pixels type: ${pixels.runtimeType} > $pixels");
+    }
+
+    return img.ColorUint32.rgba(r, g, b, a);
+  }
+
+  Uint8List pixelsToImagePNG() {
+    final pixels = this;
+
+    var w = pixels.width;
+    var h = pixels.height;
+
+    var bitmap = img.Image(
+        width: w,
+        height: h,
+        format: img.Format.uint8,
+        numChannels: 4,
+        withPalette: false);
+
+    for (var y = 0; y < h; ++y) {
+      for (var x = 0; x < w; ++x) {
+        var p = pixels.getImageColor(x, y);
+        bitmap.setPixel(x, y, p);
+      }
+    }
+
+    return img.encodePng(bitmap, singleFrame: true);
+  }
+}
+
+extension ImageExtension on img.Image {
+  Uint8List get dataAsUint8List {
+    var imageData = data as img.ImageDataUint8;
+    var dataUint8 = imageData.data;
+    return dataUint8;
+  }
+}

--- a/lib/src/pcanvas_impl_bitmap.dart
+++ b/lib/src/pcanvas_impl_bitmap.dart
@@ -1,6 +1,21 @@
+import 'dart:typed_data';
+
 import 'pcanvas_base.dart';
 import 'pcanvas_bitmap.dart';
+import 'pcanvas_bitmap_extension.dart';
 
-PCanvas createPCanvasImpl(int width, int height, PCanvasPainter painter,
-        {PCanvasPixels? initialPixels}) =>
-    PCanvasBitmap(width, height, painter, initialPixels: initialPixels);
+class PCanvasFactoryBitmap extends PCanvasFactory {
+  static final PCanvasFactoryBitmap instance = PCanvasFactoryBitmap._();
+
+  PCanvasFactoryBitmap._() : super.impl();
+
+  @override
+  PCanvas createPCanvas(int width, int height, PCanvasPainter painter,
+          {PCanvasPixels? initialPixels}) =>
+      PCanvasBitmap(width, height, painter, initialPixels: initialPixels);
+
+  @override
+  Uint8List pixelsToPNG(PCanvasPixels pixels) => pixels.pixelsToImagePNG();
+}
+
+PCanvasFactory createPCanvasFactoryImpl() => PCanvasFactoryBitmap.instance;

--- a/lib/src/pcanvas_impl_html.dart
+++ b/lib/src/pcanvas_impl_html.dart
@@ -1,6 +1,15 @@
 import 'pcanvas_base.dart';
 import 'pcanvas_html.dart';
 
-PCanvas createPCanvasImpl(int width, int height, PCanvasPainter painter,
-        {PCanvasPixels? initialPixels}) =>
-    PCanvasHTML(width, height, painter, initialPixels: initialPixels);
+class PCanvasFactoryHTML extends PCanvasFactory {
+  static final PCanvasFactoryHTML instance = PCanvasFactoryHTML._();
+
+  PCanvasFactoryHTML._() : super.impl();
+
+  @override
+  PCanvas createPCanvas(int width, int height, PCanvasPainter painter,
+          {PCanvasPixels? initialPixels}) =>
+      PCanvasHTML(width, height, painter, initialPixels: initialPixels);
+}
+
+PCanvasFactory createPCanvasFactoryImpl() => PCanvasFactoryHTML.instance;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pcanvas
 description: A portable canvas that can work in many platforms (Flutter, Web, Desktop, in-memory Image).
-version: 1.0.6
+version: 1.0.7
 homepage: https://github.com/gmpassos/pcanvas
 
 environment:


### PR DESCRIPTION
- `PCanvasPainter`:
  - Added `zIndex` to define the painter layer. Previously was fixed to `0`.
- Added `PCanvasFactory`:
  - Allows extra platform dependent implementations: - `pixelsToPNG` and `pixelsToDataUrl`
- `PCanvasBitmap.toPNG`:
  - Ensure `singleFrame: true`